### PR TITLE
systemd-unit: Fix dependencies

### DIFF
--- a/xyz.openbmc_project.SessionManager.service.in
+++ b/xyz.openbmc_project.SessionManager.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=OpenBMC Session Manager service.
 
-Before=dropbear.socket
+Before=dropbear@.service
 Before=bmcweb.service
 
 [Service]
@@ -10,5 +10,5 @@ Type=simple
 Restart=always
 
 [Install]
-WantedBy=dropbear.socket
+WantedBy=dropbear@.service
 WantedBy=bmcweb.service


### PR DESCRIPTION
systemd-unit: Fix dependencies
    
The systemd-unit configuration is invalid. The `Before=` and `WantedBy=` are conflicted between them. Reconfigure dependencies to exactly .service units.

End-user-impact: none

Signed-off-by: Igor Kononenko <i.kononenko@yadro.com>