### PR TITLE
Add functions to close sessions by privelegies

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -93,6 +93,111 @@ uint32_t SessionManager::closeAllByType(SessionType type)
     return count;
 }
 
+uint32_t SessionManager::closeUserSessionsByType(SessionType type, std::string sessionId, bool ownedOnly)
+{   
+    auto numSessId = parseSessionId(sessionId);
+    std::string userName = getSessionItem(sessionId)->getOwner();
+    bool allowed = isAllSessionsAllowed(sessionId);
+    const auto count = std::erase_if(sessionItems, [allowed, ownedOnly, type, userName, numSessId](const auto& item) {
+        auto const [id, session] = item;
+        if ((allowed) && !(ownedOnly))
+        {
+            return session->sessionType() == type &&
+                   id != numSessId;
+        }
+        else
+        {
+            return session->sessionType() == type &&
+                   session->getOwner() == userName &&
+                   id != numSessId;
+        }
+    });
+    return count;
+}
+
+bool SessionManager::isAllSessionsAllowed(std::string sessionId)
+{
+    log<level::DEBUG>("SessionManager::isOwnSession()",
+              entry("CALLER-SESSION-ID=%d", sessionId.c_str()));
+
+    std::map<std::string, std::variant<std::string, std::vector<std::string>, bool>> mapperResponse;
+    auto mapper = bus.new_method_call("xyz.openbmc_project.User.Manager", "/xyz/openbmc_project/user", "xyz.openbmc_project.User.Manager", "GetUserInfo");
+
+    std::string userName = getSessionItem(sessionId)->getOwner();
+    mapper.append(userName.c_str());
+
+    auto mapperResponseMsg = bus.call(mapper);
+    
+    if (mapperResponseMsg.is_method_error())
+    {
+        log<level::ERR>("Error getting user info",
+            entry("SERVICE=%s", "xyz.openbmc_project.User.Manager"),
+            entry("USERNAME=%s", "admin"));
+        throw InternalFailure();
+    }
+
+    mapperResponseMsg.read(mapperResponse);
+ 
+    if (mapperResponse.empty())
+    {
+        log<level::ERR>("No Object has implemented the interface",
+                        entry("SERVICE=%s", "xyz.openbmc_project.User.Manager"),
+                        entry("USERNAME=%s", "admin"));
+        elog<InternalFailure>();
+        throw InternalFailure();
+    }
+    
+    auto mapperResponseIt = mapperResponse.find("UserPrivilege");
+    if (mapperResponseIt == mapperResponse.end())
+    {
+        throw InternalFailure();
+    }
+    std::string privilegeValue  = std::get<0>(mapperResponseIt->second);
+    return (privilegeValue == "priv-admin");
+}
+
+// required to follow DRY principle, since logic would be used several times
+SessionItemPtr SessionManager::getSessionItem(std::string sessionId)
+{
+    log<level::DEBUG>("SessionManager::isOwnSession()",
+              entry("CALLER-SESSION-ID=%d", sessionId.c_str()));
+
+    auto numSessId = parseSessionId(sessionId);
+    auto foundSessionIt = sessionItems.find(numSessId);
+    if (foundSessionIt == sessionItems.end())
+    {
+        throw InvalidArgument();
+    }
+    return foundSessionIt->second;
+}
+
+bool SessionManager::isOwnSession(std::string callerSessionId, std::string removedSessionId)
+{
+    log<level::DEBUG>("SessionManager::isOwnSession()",
+                  entry("CALLER-SESSION-ID=%d", callerSessionId.c_str()),
+                  entry("REMOVED-SESSION-ID=%d", removedSessionId.c_str()));
+
+    std::string userName1 = getSessionItem(callerSessionId)->getOwner();
+    std::string userName2 = getSessionItem(removedSessionId)->getOwner();
+
+    return (userName1 == userName2);
+}
+
+void SessionManager::closeSessionById(std::string callerSessionId, std::string removedSessionId)
+{
+    log<level::DEBUG>("SessionManager::closeSessionById()",
+                      entry("CALLER-SESSION-ID=%d", callerSessionId.c_str()),
+                      entry("REMOVED-SESSION-ID=%d", removedSessionId.c_str()));
+    if ((callerSessionId == removedSessionId) ||
+        (isOwnSession(callerSessionId, removedSessionId)) ||
+        (isAllSessionsAllowed(callerSessionId)))
+    {
+        close(removedSessionId);
+    } else {
+        throw NotAllowed();
+    }
+}
+
 void SessionManager::close(std::string sessionId)
 {
     log<level::DEBUG>("SessionManager::close()",

--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -105,6 +105,22 @@ class SessionManager final :
      *         identifier
      */
     const std::string getSessionObjectPath(SessionIdentifier) const;
+     /**
+     * @brief closeSessionById check if all sessions are allowed by specified ID.
+     *
+     * @param callerSessionId     - unique caller session ID
+     * @param removedSessionId    - unique session ID to remove from storage
+     */
+    void closeSessionById(std::string callerSessionId, std::string removedSessionId) override;
+    /**
+     * @brief closeUserSessionsByType check if all sessions are allowed by specified ID.
+     *
+     * 
+     * @param type       - the type of session to close.
+     * @param sessionId  - unique caller session ID, required to check the system rights to delete another session
+     * @param ownedOnly  - true/false if admin wants to delete own sessions only
+     */
+    uint32_t closeUserSessionsByType(SessionType type, std::string sessionId, bool ownedOnly);
   protected:
     friend class SessionItem;
 
@@ -183,6 +199,33 @@ class SessionManager final :
      *        and cleanup sessions of an unavailable service.
      */
     void checkSessionOwnerAlive(const boost::system::error_code&);
+    
+    /**
+     * @brief isAllSessionsAllowed check if all sessions are allowed by specified ID.
+     *
+     * @param sessionId     - unique session ID to remove from storage
+     * 
+     * @return bool true/false - is closing all sessions allowed
+     */
+    bool isAllSessionsAllowed(std::string sessionId);
+     /**
+     * @brief isOwnSession check if the user is the owner of the given sessopn.
+     *
+     * @param callerSessionId     - unique session ID which request to terminate some other session
+     * 
+     * @param removedSessionId    - unique session ID to remove from storage
+     * 
+     * @return bool true/false - the user is the owner of the session or not
+     */
+    bool isOwnSession(std::string callerSessionId, std::string removedSessionId);
+     /**
+     * @brief getSessionItem returning one session item by session ID provided
+     *
+     * @param sessionId     - unique session ID to get the item for
+     * 
+     * @return SessionItemPtr - foundSessionIt->second, session item associated with session ID
+     */
+    SessionItemPtr getSessionItem(std::string sessionId);
   private:
     sdbusplus::bus::bus& bus;
     boost::asio::io_context& ioc;


### PR DESCRIPTION
- Add functions support functions (protected) to provide information about session owner, and user privelegies
- Add function to get the session items, in order to follow the DRY principle, because session items are required several times and repeating the same steps each time makes the code less-readable
- Added functions to actually close session by its ID and Type, but the new functions did include checks on user privelegies so that before closing a session we would be able to check if the calling session is allowed to close the requested session or not

Solves BBMC-1295
End-User-Impact: it is now possible to close
                 session by its id and type
                 using busctl, priveligies
                 being checked using the
                 caller session ID
Signed-off-by: Nikolay Chegodaev <n.chegodaev@yadro.com>