### PR TITLE
Add functions to close sessions by privelegies

### DIFF
--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -40,6 +40,7 @@ class SessionManager final :
     static constexpr const char* sessionManagerObjectPath =
         "/xyz/openbmc_project/session_manager";
     static constexpr unsigned int invalidSessionId = 0U;
+
   public:
     using SessionType = SessionItemServer::Type;
 
@@ -105,6 +106,28 @@ class SessionManager final :
      *         identifier
      */
     const std::string getSessionObjectPath(SessionIdentifier) const;
+    /**
+     * @brief closeSessionById check if all sessions are allowed by specified
+     * ID.
+     *
+     * @param callerSessionId     - unique caller session ID
+     * @param removedSessionId    - unique session ID to remove from storage
+     */
+    void closeSessionById(std::string callerSessionId,
+                          std::string removedSessionId) override;
+    /**
+     * @brief closeUserSessionsByType check if all sessions are allowed by
+     * specified ID.
+     *
+     *
+     * @param type       - the type of session to close.
+     * @param sessionId  - unique caller session ID, required to check the
+     * system rights to delete another session
+     * @param ownedOnly  - true/false if admin wants to delete own sessions only
+     */
+    uint32_t closeUserSessionsByType(SessionType type, std::string sessionId,
+                                     bool ownedOnly);
+
   protected:
     friend class SessionItem;
 
@@ -183,6 +206,38 @@ class SessionManager final :
      *        and cleanup sessions of an unavailable service.
      */
     void checkSessionOwnerAlive(const boost::system::error_code&);
+
+    /**
+     * @brief isAllSessionsAllowed check if all sessions are allowed by
+     *                             specified ID.
+     *
+     * @param sessionId - unique session ID to remove from storage
+     *
+     * @return bool true/false - is closing all sessions allowed
+     */
+    bool isAllSessionsAllowed(std::string sessionId);
+    /**
+     * @brief isOwnSession check if the user is the owner of the given sessopn.
+     *
+     * @param callerSessionId - unique session ID which request to terminate
+     *                          some other session
+     *
+     * @param removedSessionId - unique session ID to remove from storage
+     *
+     * @return bool true/false - the user is the owner of the session or not
+     */
+    bool isOwnSession(std::string callerSessionId,
+                      std::string removedSessionId);
+    /**
+     * @brief getSessionItem returning one session item by session ID provided
+     *
+     * @param sessionId - unique session ID to get the item for
+     *
+     * @return SessionItemPtr - foundSessionIt->second, session item associated
+     *                          with session ID
+     */
+    SessionItemPtr getSessionItem(std::string sessionId);
+
   private:
     sdbusplus::bus::bus& bus;
     boost::asio::io_context& ioc;


### PR DESCRIPTION
- Add functions support functions (protected) to provide information about session owner, and user privelegies
- Add function to get the session items, in order to follow the DRY principle, because session items are required several times and repeating the same steps each time makes the code less-readable
- Added functions to actually close session by its ID and Type, but the new functions did include checks on user privelegies so that before closing a session we would be able to check if the calling session is allowed to close the requested session or not

End-User-Impact: it is now possible to close
                 session by its id and type
                 using busctl, priveligies
                 being checked using the
                 caller session ID
Signed-off-by: Nikolay Chegodaev <n.chegodaev@yadro.com>